### PR TITLE
Support compressed private keys

### DIFF
--- a/sslcrypto/_ecc.py
+++ b/sslcrypto/_ecc.py
@@ -296,6 +296,14 @@ class EllipticCurve:
             return x, y
 
 
+    def is_compressed(self, wif):
+        dec = base58.b58decode_check(wif)
+        if dec[0] != 0x80:
+            raise ValueError("Invalid network (expected mainnet)")
+        if len(dec) == 34 and dec[33] == 0x01:
+            return True
+        return False
+
     def new_private_key(self):
         return self._backend.new_private_key()
 
@@ -305,14 +313,16 @@ class EllipticCurve:
         return self._encode_public_key(x, y, is_compressed=is_compressed)
 
 
-    def private_to_wif(self, private_key):
-        return base58.b58encode_check(b"\x80" + private_key)
+    def private_to_wif(self, private_key, is_compressed=False):
+        return base58.b58encode_check(b"\x80" + private_key + (b"\x01" if is_compressed else b""))
 
 
     def wif_to_private(self, wif):
         dec = base58.b58decode_check(wif)
         if dec[0] != 0x80:
             raise ValueError("Invalid network (expected mainnet)")
+        if len(dec) == 34 and dec[33] == 0x01:
+            dec = dec[:-1]
         return dec[1:]
 
 

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -84,6 +84,10 @@ def test_static(ecc):
     data = b"Hello, world!"
     entropy = b"Just some entropy"
 
+    # Compression detection
+    assert curve.is_compressed(curve.private_to_wif(priv1)) == False
+    assert curve.is_compressed(curve.private_to_wif(priv1, is_compressed=True)) == True
+
     # Basic conversions
     pub1 = curve.private_to_public(priv1)
     pub2 = curve.private_to_public(priv2)
@@ -93,6 +97,11 @@ def test_static(ecc):
     # WIF
     assert curve.private_to_wif(priv1) == b"5JF1U8yr5wZbrBCgTVtswjMR7iqC8KQ4oh4EPqeKRmnSompJVMQ"
     assert curve.wif_to_private(b"5JpCC7mMHxZ8Lw9TwUymMzdcfWeLVi8r8Tyyz5ic6G12iqAXr6E") == priv2
+
+    # Compressed WIF
+    assert curve.wif_to_private(curve.private_to_wif(priv1, is_compressed=True)) == priv1
+    assert curve.private_to_wif(priv1, is_compressed=True) == b"Ky6q4nDueoptp42Z9xXyrZw7Sfdi7JCoo5oG7ohiLLfatyKqaUAT"
+    assert curve.wif_to_private(b"L1dJQ4rkZrCoQyzMuUVYofNcQyqo3iZdqx6WWwpdtDD8bL7kro2s") == priv2
 
     # Addresses
     assert curve.public_to_address(pub1) == curve.private_to_address(priv1) == b"1553rYBLgCVA6vGYcN7AipdAeWGp9tkAw4"


### PR DESCRIPTION
This adds support for detection and better handling of compressed private keys. It's needed for HelloZeroNet/ZeroNet#2501.

It adds new function to check if address should be compressed. It also modifies `private_to_wif` to allow exporting WIF private key with compression flag and `wif_to_private` to remove flag if needed so private key is correct.